### PR TITLE
add ordering to avoid exceptions in netbox > v4.4.0

### DIFF
--- a/netbox_kea/api/views.py
+++ b/netbox_kea/api/views.py
@@ -5,6 +5,6 @@ from .serializers import ServerSerializer
 
 
 class ServerViewSet(NetBoxModelViewSet):
-    queryset = models.Server.objects.prefetch_related("tags")
+    queryset = models.Server.objects.prefetch_related("tags").order_by("-pk")
     filterset_class = filtersets.ServerFilterSet
     serializer_class = ServerSerializer


### PR DESCRIPTION
- API paginator raises out when queryset is not ordered https://github.com/netbox-community/netbox/issues/18900